### PR TITLE
doc: decrease letter count for search to 2

### DIFF
--- a/cmd/tools/vdoc/resources/doc.js
+++ b/cmd/tools/vdoc/resources/doc.js
@@ -98,7 +98,7 @@ function setupSearch() {
                 search.classList.add('hidden');
                 search.classList.remove('has-results');
             }
-        } else if (searchValue.length > 2) {
+        } else if (searchValue.length >= 2) {
             // search for less than 3 characters can display too much results
             search.innerHTML = '';
             menu.style.display = 'none';


### PR DESCRIPTION
Because we have in vlib such modules as pg, os, ui, io, gg, dl and they are pretty important we need to decrease letter threshold for search to 2



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
